### PR TITLE
OpenWrt uptime

### DIFF
--- a/netengine/backends/ssh/openwrt.py
+++ b/netengine/backends/ssh/openwrt.py
@@ -83,3 +83,12 @@ class OpenWRT(SSH):
     def RAM_total(self):
         return int(self.run("cat /proc/meminfo | grep MemTotal | awk '{print $2}'"))
 
+    @property
+    def uptime(self):
+        """
+        returns an integer representing the number of seconds of uptime
+        """
+        output = self.run('cat /proc/uptime')
+        seconds = float(output.split()[0])
+        return int(seconds)
+

--- a/tests/ssh.py
+++ b/tests/ssh.py
@@ -152,3 +152,6 @@ class TestSSHOpenWRT(unittest.TestCase):
     def test_RAM_total(self):
         self.assertTrue(type(self.device.RAM_total) == int)
 
+    def test_uptime(self):
+        self.assertTrue(type(self.device.uptime) == int)
+


### PR DESCRIPTION
Method that parse a proc file and return a integer represent the machine
uptime in seconds.
Wrote the relative test.
