### PR TITLE
OpenWrt to_dict method

### DIFF
--- a/netengine/backends/ssh/openwrt.py
+++ b/netengine/backends/ssh/openwrt.py
@@ -92,3 +92,19 @@ class OpenWRT(SSH):
         seconds = float(output.split()[0])
         return int(seconds)
 
+    def to_dict(self):
+        return self._dict({
+            "name": self.name,
+            "type": "radio",
+            "os": self.os[0],
+            "os_version": self.os[1],
+            "manufacturer": None,
+            "model": self.model,
+            "RAM_total": self.RAM_total,
+            "uptime": self.uptime,
+            "uptime_tuple": None,
+            "interfaces": None,
+            "antennas": [],
+            "routing_protocols": None,
+        })
+

--- a/tests/ssh.py
+++ b/tests/ssh.py
@@ -155,3 +155,6 @@ class TestSSHOpenWRT(unittest.TestCase):
     def test_uptime(self):
         self.assertTrue(type(self.device.uptime) == int)
 
+    def test_to_dict(self):
+        self.assertTrue(isinstance(self.device.to_dict(), dict))
+


### PR DESCRIPTION
Return a dictionary for all the properties of the OpenWRT class
Related to issue #3
